### PR TITLE
Install class notifies

### DIFF
--- a/skeleton/manifests/init.pp.erb
+++ b/skeleton/manifests/init.pp.erb
@@ -17,7 +17,7 @@ class <%= metadata.name %> (
 
   # validate parameters here
 
-  class { '::<%= metadata.name %>::install': } ->
+  class { '::<%= metadata.name %>::install': } ~>
   class { '::<%= metadata.name %>::config': } ~>
   class { '::<%= metadata.name %>::service': } ->
   Class['::<%= metadata.name %>']


### PR DESCRIPTION
Install class should notify by default to allow to restart the service after the package has been updated to a newer version.